### PR TITLE
Ensure `str_replace()` is operating on a string

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -1420,7 +1420,7 @@ class FormBuilder
      */
     protected function transformKey($key)
     {
-        return str_replace(['.', '[]', '[', ']'], ['_', '', '.', ''], $key);
+        return str_replace(['.', '[]', '[', ']'], ['_', '', '.', ''], $key ?? '');
     }
 
     /**

--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -76,6 +76,13 @@ class FormBuilder
      */
     protected $labels = [];
 
+    /**
+     * An array of payloads we've created.
+     *
+     * @var array
+     */
+    protected $payload = [];
+
     protected $request;
 
     /**


### PR DESCRIPTION
These errors showed up in my deprecation log so figured I'd contribute the change.

- Ensure dynamic property `Collective\Html\FormBuilder::$payload` is defined
- Ensure `str_replace()` is operating on a string